### PR TITLE
Addressing the COCO dataset error

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,23 @@ in the folder ``./models/detectors`` and change the folder name from ``PyTorch-Y
     simple-HRNet
     ├── datasets                (datasets - for training only)
     │  └── COCO                 (COCO dataset)
+        └── annotations
+            └── person_keypoints_train2017.json
+            └── person_keypoints_val2017.json
+        └── person_detection_results
+            └── COCO_val2017_detections_AP_H_56_person.json
+            └── COCO_test-dev2017_detections_AP_H_609_person.json
+        └── images
+            └── train2017
+                └── 000000000009.jpg
+                └── 000000000025.jpg
+                └── 000000000030.jpg
+                └── ... 
+            └── val2017
+                └── 000000000139.jpg
+                └── 000000000285.jpg
+                └── 000000000632.jpg
+                └── ... 
     ├── losses                  (loss functions)
     ├── misc                    (misc)
     │  └── nms                  (CUDA nms module - for training only)

--- a/datasets/COCO.py
+++ b/datasets/COCO.py
@@ -220,7 +220,7 @@ class COCODataset(Dataset):
                 self.data.append({
                     'imgId': imgId,
                     'annId': obj['id'],
-                    'imgPath': os.path.join(self.root_path, self.data_version, '%012d.jpg' % imgId),
+                    'imgPath': os.path.join(self.root_path, "images", self.data_version,'%012d.jpg' % imgId),
                     'center': center,
                     'scale': scale,
                     'joints': joints,
@@ -245,6 +245,7 @@ class COCODataset(Dataset):
 
         # Read the image from disk
         image = cv2.imread(joints_data['imgPath'], cv2.IMREAD_COLOR | cv2.IMREAD_IGNORE_ORIENTATION)
+        print(joints_data['imgPath'])
 
         if self.color_rgb:
             image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)

--- a/datasets/COCO.py
+++ b/datasets/COCO.py
@@ -245,7 +245,6 @@ class COCODataset(Dataset):
 
         # Read the image from disk
         image = cv2.imread(joints_data['imgPath'], cv2.IMREAD_COLOR | cv2.IMREAD_IGNORE_ORIENTATION)
-        print(joints_data['imgPath'])
 
         if self.color_rgb:
             image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)


### PR DESCRIPTION
Hello, as I previously have reported, it was indeed an issue with wrong file directory.
It has nothing to do with absolute directory (pointed out by you).

Simply adding "images" in the `imgPath` in `datasets/COCO.py` solved the issue.
I have also added in README how the folder should look like, referring to @leoxiaobin 's HRNet repository.